### PR TITLE
Fill remaining keywords for bar/scatter/pie

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,1 +1,0 @@
-# streamlit-victorycharts

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,21 +3,9 @@ import streamlit as st
 
 # Create a _RELEASE constant. We'll set this to False while we're developing
 # the component, and True when we're ready to package and distribute it.
-# (This is, of course, optional - there are innumerable ways to manage your
-# release process.)
 _RELEASE = False
 
-# Declare a Streamlit component. `st.declare_component` returns a function
-# that is used to create instances of the component. We're naming this
-# function "_component_func", with an underscore prefix, because we don't want
-# to expose it directly to users. Instead, we will create a custom wrapper
-# function, below, that will serve as our component's public API.
-
-# It's worth noting that this call to `st.declare_component` is the
-# *only thing* you need to do to create the binding between Streamlit and
-# your component frontend. Everything else we do in this file is simply a
-# best practice.
-
+# Declare a Streamlit component
 if not _RELEASE:
     _component_func = st.declare_component(
         # We give the component a simple, descriptive name ("my_component"

--- a/src/frontend/src/VictoryChart.tsx
+++ b/src/frontend/src/VictoryChart.tsx
@@ -56,6 +56,7 @@ class MyComponent extends StreamlitComponentBase {
     const commonProps = [
       "categories",
       "containerComponent",
+      "cornerRadius",
       "data",
       //"dataComponent", // having this set as None from Python makes React error
       "eventKey",  //not commonly used
@@ -76,23 +77,43 @@ class MyComponent extends StreamlitComponentBase {
 
     const renderSubPlot = () => {
       if (chart_type === 'bar') {
+
         const barPropsList = commonProps.concat(["alignment", "barRatio", "barWidth", "cornerRadius"]);
         return <VictoryBar {..._.pick(this.props.args, barPropsList)} />
+
       } else {
-        const scatterPropsList = commonProps.concat(["symbol", "size"])
+
+        const scatterPropsList = commonProps.concat(["maxBubbleSize", "minBubbleSize", "size", "symbol"])
         return <VictoryScatter {..._.pick(this.props.args, scatterPropsList)} />
+
       }
     }
 
     const renderPlot = () => {
       if (chart_type === 'pie') {
-        const piePropsList = commonProps.concat(["radius", "startAngle", "endAngle"]);
+
+        const piePropsList = commonProps.concat(
+          [
+            "colorScale",
+            "cornerRadius",
+            "endAngle",
+            "innerRadius",
+            "labelPosition",
+            "labelRadius",
+            "padAngle",
+            "radius",
+            "startAngle"
+          ]
+        );
         return <VictoryPie  {..._.pick(this.props.args, piePropsList)} />
+
       } else {
         return (
+
           <VictoryChart {..._.pick(this.props.args, chartPropList)}>
             {renderSubPlot()}
           </VictoryChart>
+
         )
       }
     }


### PR DESCRIPTION
On the React side, fill in the remaining chart-specific keywords. Also remove incorrect README and delete more template comments.